### PR TITLE
added netlify support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "dist"
+  command = "gridsome build"


### PR DESCRIPTION
Added netlify.toml to build & deploy gridsome-starter-casper-v3 properly from https://gridsome.org/starters/gridsome-casper-v3-starter/ > "Install now" > "Deploy with Netlify"