### PR TITLE
Add template paths to be purge by tailwind

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ var flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').de
 
 
 module.exports = {
+  purge: ["./src/**/*.html", "./src/**/*.vue", "./src/**/*.jsx"],
   theme: {
     borderWidth: {
       default: '1px',


### PR DESCRIPTION
Purge paths are missing

Warning log:
   ⚠️  Tailwind is not purging unused styles because no template paths have been provided.
      If you have manually configured PurgeCSS outside of Tailwind or are deliberately not
      removing unused styles, set `purge: false` in your Tailwind config file to silence
      this warning.

      https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css